### PR TITLE
New option sendRetryOnReconnect as a fallback when Rainbow Connection is Down.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Here is the list of the changes and features provided by the **node-red-contrib-
 - Implementation of a new option : sendRetryOnReconnect
   Keep message to send in a buffer when the connection is down and re-send it when connection is up again.
   The buffer length is limited to 500 entries.
+  The resent message content can be prefixed with a configurable text. The keywork :DATE: can be used inside and will be
+  replaced by the date of initial message.
 
 ## [1.82.1] - 2022-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,102 +2,142 @@
 
 Here is the list of the changes and features provided by the **node-red-contrib-ale-rainbow**
 
+## [1.82.2] - 2022-06-15
+
+- Fixing Rainbow SDK dependency (2.10.0-lts.10)
+- Implementation of a new option : sendRetryOnReconnect
+  Keep message to send in a buffer when the connection is down and re-send it when connection is up again.
+  The buffer length is limited to 500 entries.
+
 ## [1.82.1] - 2022-06-15
--   Update for jenkins.
+
+- Update for jenkins.
 
 ## [1.82.0] - 2022-06-15
--   Add logs when a `rainbow_onxmpperror` event is received.
+
+- Add logs when a `rainbow_onxmpperror` event is received.
 
 ## [1.81.0] - 2021-11-24
--   Add sdkLogInternals boolean to manage the option "internals" provided to Rainbow Node SDK (only with earlier SDK LTS 2.1.0 and STS 2.6)
--   Add sdkLogHttp boolean to manage the option "internals" provided to Rainbow Node SDK (only with earlier SDK LTS 2.1.0 and STS 2.6)
--   Add urgency parameter to sendMessage component (only with earlier SDK LTS 2.1.0 and STS 2.6).
--   Add a new node to listen every rainbow SDK public event. It needs Rainbow Node SDK 2.6.2 or earlier.
+
+- Add sdkLogInternals boolean to manage the option "internals" provided to Rainbow Node SDK (only with earlier SDK LTS
+  2.1.0 and STS 2.6)
+- Add sdkLogHttp boolean to manage the option "internals" provided to Rainbow Node SDK (only with earlier SDK LTS 2.1.0
+  and STS 2.6)
+- Add urgency parameter to sendMessage component (only with earlier SDK LTS 2.1.0 and STS 2.6).
+- Add a new node to listen every rainbow SDK public event. It needs Rainbow Node SDK 2.6.2 or earlier.
 
 ## [1.80.0] - 2020-11-30
--   Add in node CnxState a second output with the log of the law layer Rainbow Node SDK (The logs are retrieved from an event publisher).
--   Split the log's options in console, file, event.
+
+- Add in node CnxState a second output with the log of the law layer Rainbow Node SDK (The logs are retrieved from an
+  event publisher).
+- Split the log's options in console, file, event.
 
 ## [1.69.11] - 2020-04-01
--   Same as version 1.69.1 (work on build process)
+
+- Same as version 1.69.1 (work on build process)
 
 ## [1.69.1] - 2020-03-31
--   update documentation
--   update cnx node to allow the configuration of the rainbow-node-sdk from the flow :
+
+- update documentation
+- update cnx node to allow the configuration of the rainbow-node-sdk from the flow :
     * sdkLog to activate the log on console and also in a file `YYYY-MM-DD-rainbowsdk.log` in `%TEMP%` folder.
-    * messageMaxLength to set the max size of a message sent in XMPP engine (Note: there is a limitation to 1024 on server side)
-    * sendMessageToConnectedUser to allow the connected user to be the destination of a sent message. When setted to false, it avoid a bot to discuss with himself and deadlock.
-    * conversationsRetrievedFormat to allow to set the quantity of datas retrieved when SDK get conversations from server. Value can be "small" of "full"
-    * storeMessages Define a server side behaviour with the messages sent. When true, the messages are stored, else messages are only available on the fly. They can not be retrieved later.
-    * nbMaxConversations parameter to set the maximum number of conversations to keep (defaut value to 15). Old ones are removed from XMPP server. They are not destroyed. The can be activated again with a send to the conversation again.
-    * rateLimitPerHour to set the maximum count of stanza messages of type `message` sent during one hour. The counter is started at startup, and reseted every hour.
+    * messageMaxLength to set the max size of a message sent in XMPP engine (Note: there is a limitation to 1024 on
+      server side)
+    * sendMessageToConnectedUser to allow the connected user to be the destination of a sent message. When setted to
+      false, it avoid a bot to discuss with himself and deadlock.
+    * conversationsRetrievedFormat to allow to set the quantity of datas retrieved when SDK get conversations from
+      server. Value can be "small" of "full"
+    * storeMessages Define a server side behaviour with the messages sent. When true, the messages are stored, else
+      messages are only available on the fly. They can not be retrieved later.
+    * nbMaxConversations parameter to set the maximum number of conversations to keep (defaut value to 15). Old ones are
+      removed from XMPP server. They are not destroyed. The can be activated again with a send to the conversation
+      again.
+    * rateLimitPerHour to set the maximum count of stanza messages of type `message` sent during one hour. The counter
+      is started at startup, and reseted every hour.
 
 ## [1.4.2] - 2019-02-12
+
 update to rainbow-node-sdk 1.52.0
 
 ## [1.4.1] - 2019-02-12
 
 ## [1.3.6] - 2018-11-06
+
 Login node: add host selection to choose between sandbox and official rainbow systems.
 
 ## [1.3.5] - 2018-09-07
+
 Update documentation
 
 ## [1.3.4] - 2018-09-03
+
 - Login node: add appID and secret which will be mandatory soon in production
 - Send_IM node: allow to also modify Bubble's customData (only for Bubble owner)
-Thanks to loloj
+  Thanks to loloj
 - Send_Channel and Notified_Channel nodes added
 - Add some icons for Rainbow Nodes...
 
 ## [1.3.3] - 2018-07-00
+
 - Add new node Rainbow_function to allow to call a specific API in Rainbow Node.js SDK
-Thanks to Christian Foricher
+  Thanks to Christian Foricher
 
 ## [1.3.2] - 2018-05-30
+
 - Remove JSON.stringify also for Notify IM
 - Add counter also for IM messages got
 
 ## [1.3.1] - 2018-04-11
+
 - Remove JSON.stringify logs which crashed (circular)
 - Add counter to Send_IM node
 
 ## [1.3.0] - 2018-04-11
+
 - Jump to 1.3 version: multi user supported (needs also dependency rainbow-node-sdk v1.39.0)
 - thanks to Loic Jehanno for his help !
 - git issues/4 corrected also (Error while Deploy (stop/start) with Contacts._onRosterPresenceChanged in dependency)
 
 ## [1.2.8] - 2018-03-28
+
 - issues/7 on git: correction for receiving msg from room
 - Notified_IM: 2 options ignorechat and ignoregroupchat to allow to filter one to one chat, and/or group chat
 - Notified_IM: add some documentation about "fromBubbleUserJid" and "type" in the message
 - Notified_IM: in case od "groupchat" type, also send the bubble in the payload
 
 ## [1.2.7] - 2018-03-05
+
 - Notified_IM now also give payload.contact which contains sender informations
 - Dependency update: SDK Node.js
 
 ## [1.2.6] - 2018-02-03
+
 - Add some documentation on usable parameters got from Notified_IM
 - Add Markdown support (alternative content)
 
 ## [1.2.5] - 2018-01-24
+
 - Not reproductible: closing issue onRainbowError() : XMPPERROR #5
 - Rewite some docs in nodes to match new node-red format, update the README.md
 - Refactor code
-- There are "Error while Deploy (stop/start)" which should be corrected with next dependency version (Rainbow Node.js SDK)
-- Added in Notified_IM node 2 filters: filterContact and filterCompany to only accept message from a user of from a company
+- There are "Error while Deploy (stop/start)" which should be corrected with next dependency version (Rainbow Node.js
+  SDK)
+- Added in Notified_IM node 2 filters: filterContact and filterCompany to only accept message from a user of from a
+  company
 - Corrected issue: RegExp Filter typo #6
 
 ## [1.2.4] - 2018-01-19
+
 - Corrections for https://github.com/Rainbow-CPaaS/node-red-contrib-ale-rainbow/issues/3 to allow msg in a bubble
 - Code refactoring: add missing state events, add started/stopped states
 - implement also new on "close" from node-red
 
 ## [1.2.2] - [1.2.3] - 2018-01-18
+
 - Do some corrections in package.json
 
 ## [1.2.1] - 2018-01-16
+
 - Add this Changelog
 - Improve cleanup: stop node.js SDK also to close event socket
 - Correction for issue 'Error stopping node #2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Here is the list of the changes and features provided by the **node-red-contrib-ale-rainbow**
 
-## [1.82.2] - 2022-09-06
+## [1.82.3] - 2022-09-06
 
 - Fixing Rainbow SDK dependency (2.10.0-lts.10)
 - Implementation of a new option : sendRetryOnReconnect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Here is the list of the changes and features provided by the **node-red-contrib-ale-rainbow**
 
-## [1.82.2] - 2022-06-15
+## [1.82.2] - 2022-09-06
 
 - Fixing Rainbow SDK dependency (2.10.0-lts.10)
 - Implementation of a new option : sendRetryOnReconnect

--- a/ale-rainbow/ale-rainbow.html
+++ b/ale-rainbow/ale-rainbow.html
@@ -14,6 +14,7 @@
           sdkEventsLog: {value:false},
           sdkLogInternals: {value:false},
           sdkLogHttp: {value:false},
+          useErrorMsgBuffer: {value: false},
           ackIM: {value:false},
           messageMaxLength: {value:1024, required:false},
           sendMessageToConnectedUser: {value:false, required:false},
@@ -546,7 +547,7 @@
         </p>
         <h3>Output :</h3>
         <h4>First output:</h4>
-        
+
         <p><code>msg.payload</code> contains connection status (string).<br>
         It can be :</p>
         <ul>
@@ -557,7 +558,7 @@
         </ul>
         <h4>Second output:</h4>
         This output is used to get SDK logs. It needs the "sdkEventsLog" checkbox to be checked in the window with authentication to rainbow. Note that it is a process that can dry resources, so it would be used in tests only.
-		
+
     </script>
 
     <script type="text/x-red" data-template-name="Login">
@@ -625,6 +626,10 @@
         <div class="form-row">
             <label for="node-config-input-sdkLogHttp" title="Activate the log of network trafic."><i class="icon-tag"></i> sdkLogHttp</label>
             <input type="checkbox" id="node-config-input-sdkLogHttp" >
+        </div>
+        <div class="form-row">
+            <label for="node-config-input-useErrorMsgBuffer" title="When the connection is down, we buffer the msg to send and wait for connection to be up again. A prefix will be added to content, to show that message sending has been delayed."><i class="icon-tag"></i> useErrorMsgBuffer</label>
+            <input type="checkbox" id="node-config-input-useErrorMsgBuffer" >
         </div>
         <div class="form-row">
             <label for="node-config-input-ackIM" title="Automatic acknowledge of incoming IM"><i class="icon-tag"> sendReadReceipt</i> </label>

--- a/ale-rainbow/ale-rainbow.html
+++ b/ale-rainbow/ale-rainbow.html
@@ -15,6 +15,7 @@
           sdkLogInternals: {value:false},
           sdkLogHttp: {value:false},
           sendRetryOnReconnect: {value: false},
+          retryPrefixTemplate: {type:"text", value: "Delayed message: :DATE:"},
           ackIM: {value:false},
           messageMaxLength: {value:1024, required:false},
           sendMessageToConnectedUser: {value:false, required:false},
@@ -630,6 +631,10 @@
         <div class="form-row">
             <label for="node-config-input-sendRetryOnReconnect" title="When the connection is down, we buffer the msg to send and wait for connection to be up again. A prefix will be added to content, to show that message sending has been delayed."><i class="icon-tag"></i> sendRetryOnReconnect</label>
             <input type="checkbox" id="node-config-input-sendRetryOnReconnect" >
+        </div>
+         <div class="form-row">
+            <label for="node-config-input-retryPrefixTemplate" title="Retry prefix text template, :DATE: keyword will be replaced with UTC date of message. Keep empty to disable it."><i class="icon-tag"></i> Retry prefix label</label>
+            <input type="text" id="node-config-input-retryPrefixTemplate">
         </div>
         <div class="form-row">
             <label for="node-config-input-ackIM" title="Automatic acknowledge of incoming IM"><i class="icon-tag"> sendReadReceipt</i> </label>

--- a/ale-rainbow/ale-rainbow.html
+++ b/ale-rainbow/ale-rainbow.html
@@ -14,7 +14,7 @@
           sdkEventsLog: {value:false},
           sdkLogInternals: {value:false},
           sdkLogHttp: {value:false},
-          useErrorMsgBuffer: {value: false},
+          sendRetryOnReconnect: {value: false},
           ackIM: {value:false},
           messageMaxLength: {value:1024, required:false},
           sendMessageToConnectedUser: {value:false, required:false},
@@ -628,8 +628,8 @@
             <input type="checkbox" id="node-config-input-sdkLogHttp" >
         </div>
         <div class="form-row">
-            <label for="node-config-input-useErrorMsgBuffer" title="When the connection is down, we buffer the msg to send and wait for connection to be up again. A prefix will be added to content, to show that message sending has been delayed."><i class="icon-tag"></i> useErrorMsgBuffer</label>
-            <input type="checkbox" id="node-config-input-useErrorMsgBuffer" >
+            <label for="node-config-input-sendRetryOnReconnect" title="When the connection is down, we buffer the msg to send and wait for connection to be up again. A prefix will be added to content, to show that message sending has been delayed."><i class="icon-tag"></i> sendRetryOnReconnect</label>
+            <input type="checkbox" id="node-config-input-sendRetryOnReconnect" >
         </div>
         <div class="form-row">
             <label for="node-config-input-ackIM" title="Automatic acknowledge of incoming IM"><i class="icon-tag"> sendReadReceipt</i> </label>

--- a/ale-rainbow/ale-rainbow.js
+++ b/ale-rainbow/ale-rainbow.js
@@ -797,7 +797,7 @@ module.exports = function (RED) {
                 return;
             }
             // RegExp filter ?
-            if ((node.filter != '') && (node.filter !== undefined)) {
+            if ((node.filter !== '') && (node.filter !== undefined)) {
                 var regexp = new RegExp(node.filter, 'img');
                 node.log("Rainbow : Apply filter :" + node.filter + " cnx: " + JSON.stringify(node.server.name));
                 var res = JSON.stringify(message.content).match(regexp);

--- a/ale-rainbow/ale-rainbow.js
+++ b/ale-rainbow/ale-rainbow.js
@@ -8,7 +8,7 @@ module.exports = function (RED) {
         node.log("RainbowSDK instance allocated" + " cnx: " + JSON.stringify(server.name));
         let handler;
         server.rainbow.sdk = new _RainbowSDK(server.rainbow.options);
-        if (server.rainbow.sdkhandler != undefined && server.rainbow.sdkhandler.length != 0) {
+        if (server.rainbow.sdkhandler !== undefined && server.rainbow.sdkhandler.length !== 0) {
             node.log("RainbowSDK : Re-registering event handlers");
             for (var i = 0, len = server.rainbow.sdkhandler.length; i < len; i++) {
                 handler = server.rainbow.sdkhandler[i];
@@ -17,7 +17,7 @@ module.exports = function (RED) {
         } else {
             server.rainbow.sdkhandler = [];
         }
-        if (server.rainbow.sdkLoghandler != undefined && server.rainbow.sdkLoghandler.length != 0) {
+        if (server.rainbow.sdkLoghandler !== undefined && server.rainbow.sdkLoghandler.length !== 0) {
             node.log("RainbowSDK : Re-registering event Log handlers");
             for (var i = 0, len = server.rainbow.sdkLoghandler.length; i < len; i++) {
                 handler = server.rainbow.sdkLoghandler[i];
@@ -47,7 +47,7 @@ module.exports = function (RED) {
         if (server.rainbow.sdk === null) {
             return
         }
-        ;
+
         server.rainbow.sdk.stop().catch(function (e) {
             node.log("catched error during pauseSDK stop : " + " cnx: " + JSON.stringify(e)); // "zut !"
             if (typeof done === "function") done();
@@ -70,21 +70,21 @@ module.exports = function (RED) {
         if (server.rainbow.sdk === null) {
             return
         }
-        ;
+
         var handler = server.rainbow.sdkhandler.pop();
         while (handler) {
             node.log("Remove listenner function :" + handler.fct.name + " cnx: " + JSON.stringify(server.name));
             server.rainbow.sdk.events.eee.removeListener(handler.evt, handler.fct);
             handler = server.rainbow.sdkhandler.pop();
         }
-        ;
+
         handler = server.rainbow.sdkLoghandler.pop();
         while (handler) {
             node.log("Remove Log listenner function :" + handler.fct.name + " cnx: " + JSON.stringify(server.name));
             server.rainbow.sdk.events.removeLogListener(handler.evt, handler.fct);
             handler = server.rainbow.sdkLoghandler.pop();
         }
-        ;
+
     }
 
     function login(config) {
@@ -164,7 +164,7 @@ module.exports = function (RED) {
                 "protocol": config.proxyProto
             },
             "im": {
-                "sendReadReceipt": config.ackIM, // True to send the the 'read' receipt automatically
+                "sendReadReceipt": config.ackIM, // True to send the 'read' receipt automatically
                 "messageMaxLength": config.messageMaxLength,
                 "sendMessageToConnectedUser": config.sendMessageToConnectedUser,
                 "conversationsRetrievedFormat": config.conversationsRetrievedFormat,
@@ -187,15 +187,15 @@ module.exports = function (RED) {
         node.log("ENV : https_proxy=" + process.env.https_proxy + " cnx: " + JSON.stringify(node.name));
         var ConnectionFail = function ConnectionFail() {
             successiveCOnnectionFail++;
-            if (config.proxyHost != "") {
+            if (config.proxyHost !== "") {
                 //We are configure to work behind a proxy.
-                if (successiveCOnnectionFail == 5) {
+                if (successiveCOnnectionFail === 5) {
                     // 5 successive fail, let's try to change proxy config
                     node.rainbow.options.proxy.host = "";
                     node.rainbow.options.proxy.port = "";
                     node.rainbow.options.proxy.proto = "";
                 }
-                if (successiveCOnnectionFail == 10) {
+                if (successiveCOnnectionFail === 10) {
                     // Still failling, let's retry on default config
                     successiveCOnnectionFail = 0;
                     node.rainbow.options.proxy.host = config.proxyHost;
@@ -670,18 +670,18 @@ module.exports = function (RED) {
                     });
                     return;
                 }
-                let destJid = (msg.payload.destJid != undefined ? msg.payload.destJid : (node.destJid != "" ? node.destJid : msg.payload.fromJid));
+                let destJid = (msg.payload.destJid !== undefined ? msg.payload.destJid : (node.destJid !== "" ? node.destJid : msg.payload.fromJid));
                 let lang = msg.payload.lang ? msg.payload.lang : null;
                 let content = msg.payload.content;
                 let alternateContent = (msg.payload.alternateContent ? msg.payload.alternateContent : null);
                 let subject = (msg.payload.subject ? msg.payload.subject : null);
                 let mentions = (msg.payload.mentions ? msg.payload.mentions : null);
                 let urgency = (msg.payload.urgency ? msg.payload.urgency : null);
-                if (destJid != undefined && "" != destJid) {
+                if (destJid !== undefined && "" !== destJid) {
                     node.log("Rainbow SDK (" + config.server + " " + content + " " + node.destJid + " " + JSON.stringify(alternateContent) + " cnx: " + JSON.stringify(node.server.name));
                     if (destJid.substring(0, 5) === "room_") {
                         var bubbleJid = destJid.split("/")[0]
-                        if (msg.payload.customData != undefined) {
+                        if (msg.payload.customData !== undefined) {
                             node.server.rainbow.sdk.bubbles.getBubbleByJid(bubbleJid).then(bubble => {
                                 if (bubble !== null) {
                                     node.server.rainbow.sdk.bubbles.setBubbleCustomData(bubble, msg.payload.customData).then(function () {
@@ -750,7 +750,7 @@ module.exports = function (RED) {
             node.server.rainbow.sdk.contacts.getContactByJid(fromJID).then((contact) => {
                 if (contact) {
                     // Contact filter ?
-                    if ((node.filterContact != '') && (node.filterContact != undefined)) {
+                    if ((node.filterContact !== '') && (node.filterContact !== undefined)) {
                         if ((node.filterContact === contact.loginEmail) || (node.filterContact === contact.jid_im)) {
                             node.log("Rainbow : Contact filter OK !" + " cnx: " + JSON.stringify(node.server.name));
                         } else {
@@ -759,7 +759,7 @@ module.exports = function (RED) {
                         }
                     }
                     // Company filter ?
-                    if ((node.filterCompany != '') && (node.filterCompany != undefined)) {
+                    if ((node.filterCompany !== '') && (node.filterCompany !== undefined)) {
                         if (node.filterCompany === contact.companyId) {
                             node.log("Rainbow : Company id filter OK !" + " cnx: " + JSON.stringify(node.server.name));
                         } else {
@@ -797,7 +797,7 @@ module.exports = function (RED) {
                 return;
             }
             // RegExp filter ?
-            if ((node.filter != '') && (node.filter != undefined)) {
+            if ((node.filter != '') && (node.filter !== undefined)) {
                 var regexp = new RegExp(node.filter, 'img');
                 node.log("Rainbow : Apply filter :" + node.filter + " cnx: " + JSON.stringify(node.server.name));
                 var res = JSON.stringify(message.content).match(regexp);
@@ -855,7 +855,7 @@ module.exports = function (RED) {
         node.log("Rainbow : notifyMessageRead node initialized :" + JSON.stringify(node.server.name))
         var rainbow_onmessagereceiptreadreceived_notifyMessageRead = function (message) {
             node.log("Rainbow : onMessageReceiptReadReceived")
-            if ((node.filter != '') && (node.filter != undefined)) {
+            if ((node.filter !== '') && (node.filter !== undefined)) {
                 var regexp = new RegExp(node.filter, 'img');
                 node.log("Rainbow : Apply filter :" + node.filter);
                 var res = JSON.stringify(contact).match(regexp);
@@ -926,7 +926,7 @@ module.exports = function (RED) {
         node.log("Rainbow : getContactsPresence node initialized :" + JSON.stringify(node.server.name))
         var rainbow_oncontactpresencechanged_getContactsPresence = function rainbow_oncontactpresencechanged_getContactsPresence(contact) {
             node.log("Rainbow : onContactPresenceChanged");
-            if ((node.filter != '') && (node.filter != undefined)) {
+            if ((node.filter !== '') && (node.filter !== undefined)) {
                 var regexp = new RegExp(node.filter, 'img');
                 node.log("Rainbow : Apply filter :" + node.filter);
                 node.log("Rainbow : on content :" + util.inspect(contact));
@@ -1042,11 +1042,11 @@ module.exports = function (RED) {
                     text: "not connected"
                 });
             } else {
-                let channel = (msg.payload.channel != undefined ? msg.payload.channel : (node.channelId != "" ? {id: node.channelId} : null));
+                let channel = (msg.payload.channel !== undefined ? msg.payload.channel : (node.channelId !== "" ? {id: node.channelId} : null));
                 let message = msg.payload.content;
                 let title = (msg.payload.title ? msg.payload.title : null);
                 let url = (msg.payload.url ? msg.payload.url : null);
-                if (channel != undefined && null != channel && channel.id != undefined && "" !== channel.id) {
+                if (channel !== undefined && null != channel && channel.id !== undefined && "" !== channel.id) {
                     node.log("Sending to id " + channel.id + " (" + message + " " + ") cnx: " + JSON.stringify(node.server.name));
 
                     node.server.rainbow.sdk.channels.publishMessageToChannel(
@@ -1091,7 +1091,7 @@ module.exports = function (RED) {
         var rainbow_onchannelmessagereceivedGetMessageFromChannel = function rainbow_onchannelmessagereceivedGetMessageFromChannel(message) {
             node.log("Rainbow : onChannelMessageReceived: " + JSON.stringify(node.server.name))
 
-            if (node.channelId != undefined && node.channelId != "") {
+            if (node.channelId !== undefined && node.channelId !== "") {
                 if (node.channelId !== message.channelId) {
                     // Not wanted channel, filtering
                     node.log("Rainbow : onChannelMessageReceived: ignoring message as not from good channel id");

--- a/ale-rainbow/ale-rainbow.js
+++ b/ale-rainbow/ale-rainbow.js
@@ -647,7 +647,7 @@ module.exports = function (RED) {
                         node.warn("Buffer has reached its limit, so we drop the oldest message !");
                     }
 
-                    if (msg.payload.content.search('Delayed msg :') === -1) {
+                    if (msg.payload.content && msg.payload.content.search('Delayed msg :') === -1) {
                         msg.payload.content = 'Delayed msg : ' + new Date().toUTCString() + '\n' + msg.payload.content;
                     }
                     errorMsgBuffer.push({msg: msg, node: node});

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
   "name": "node-red-contrib-ale-rainbow",
-  "version": "1.80.0",
+  "version": "1.82.2",
   "description": "Alcatel-Lucent Enterprise Rainbow Nodes for Node Red",
   "scripts": {
     "startnodered": "node-red -v %NODE_DEBUG_OPTION% "
   },
   "dependencies": {
     "colors": "^1.4.0",
-    "node-red-contrib-ale-rainbow": "~1.81.0",
     "node-red-dashboard": "~3.1.7",
-    "rainbow-node-sdk": "latest"
+    "rainbow-node-sdk": "2.10.0-lts.10"
   },
   "keywords": [
     "node-red",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-ale-rainbow",
-  "version": "1.82.2",
+  "version": "1.82.3",
   "description": "Alcatel-Lucent Enterprise Rainbow Nodes for Node Red",
   "scripts": {
     "startnodered": "node-red -v %NODE_DEBUG_OPTION% "


### PR DESCRIPTION
Implementation of a new option : sendRetryOnReconnect
Keep message to send in a buffer when the connection is down and resend it when connection is up again.
The buffer length is limited to 500 entries.
The re-sent message content can be prefixed with a configurable text. 
The keywork :DATE: can be used inside and will be replaced by the date of initial message.